### PR TITLE
chore: remove debug flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libpid"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MPL-2.0"
 description = "A rust crate library that implements a PID controller."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,6 @@ pub struct PID {
     max: f64,
     // timer for elapsed time between control loop steps
     timer: Option<std::time::Instant>,
-    // enable debugging
-    debug: bool,
     // add an optional label (for debugging)
     debug_label: String,
 }
@@ -44,17 +42,8 @@ impl PID {
             input_min: 0.0,
             input_max: 0.0,
             timer: None,
-            debug: false,
             debug_label: String::from(""),
         }
-    }
-
-    pub fn enable_debug(&mut self) {
-        self.debug = true;
-    }
-
-    pub fn disable_debug(&mut self) {
-        self.debug = true;
     }
 
     pub fn add_debug_label(&mut self, s: &str) {
@@ -123,17 +112,15 @@ impl PID {
         // Clamp output within desired range
         output = self.clamp_output(output);
 
-        if self.debug {
-            debug!("{}SP: {}, PV: {}, ERR: {}, ERR_SUM: {}, ERR_DT: {}, OUT: {}",
-                self.debug_label,
-                self.sp,
-                self.pv,
-                err,
-                self.err_sum,
-                err_dt,
-                output
-            );
-        }
+        debug!("{}SP: {}, PV: {}, ERR: {}, ERR_SUM: {}, ERR_DT: {}, OUT: {}",
+               self.debug_label,
+               self.sp,
+               self.pv,
+               err,
+               self.err_sum,
+               err_dt,
+               output
+        );
 
         output
     }


### PR DESCRIPTION
We don't need this debug flag since we are using tokio tracing which will use the RUST_LOG environment variable to figure out what the logging level is. 